### PR TITLE
Adding new filter for converting Unix timestamp to human readable time

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,21 +129,6 @@ A library of common AngularJS filters. Each filter is individually tested for va
   </tr>
 </table>
 
-### Other Filters
-<table>
-  <tr>
-   <th>Filter</th>
-   <th>Usage</th>
-   <th>Result</i></th>
-  </tr>
-  <tr>
-   <td><i><b>unixtimestamp</b></i></td>
-   <td><i>123456789 | unixtimestamp</i></td>
-   <td><i>30  Nov  1973  -  1:3:9</i></td>
-  </tr>
-</table>
-
-
 ### Unit Testing
 Each of the filter is covered by Unit Test extensively.  If you find any input unhandelled, please let me know. Run the unit tests using following commands:
  ```

--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ A library of common AngularJS filters. Each filter is individually tested for va
   </tr>
 </table>
 
+### Other Filters
+<table>
+  <tr>
+   <th>Filter</th>
+   <th>Usage</th>
+   <th>Result</i></th>
+  </tr>
+  <tr>
+   <td><i><b>unixtimestamp</b></i></td>
+   <td><i>123456789 | unixtimestamp</i></td>
+   <td><i>30  Nov  1973  -  1:3:9</i></td>
+  </tr>
+</table>
+
+
 ### Unit Testing
 Each of the filter is covered by Unit Test extensively.  If you find any input unhandelled, please let me know. Run the unit tests using following commands:
  ```

--- a/filters.js
+++ b/filters.js
@@ -122,13 +122,7 @@ angular.module("ch.filters",[])
         } else {
             var t = new Date(number * 1000);
             var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-            var year = t.getFullYear();
-            var month = months[t.getMonth()];
-            var day = t.getDate();
-            var hour = t.getHours();
-            var min = t.getMinutes();
-            var sec = t.getSeconds();
-            var time = day +'/'+month+'/'+year+' '+hour+':'+min+':'+sec;
+            var time = t.getDate() +'/'+ months[t.getMonth()]+'/'+t.getFullYear()+' '+t.getHours()+':'+t.getMinutes()+':'+t.getSeconds();
             return time;
         }
     }

--- a/filters.js
+++ b/filters.js
@@ -113,4 +113,24 @@ angular.module("ch.filters",[])
     return arr.reverse();   
   } 
  }                
-]);
+]).filter("unixtimestamp", [function() {
+    return function(number) {
+        // Is the passed data a number?
+        if(isNaN(number) || number < 1) {
+            // If not number, just return the entered value (Do not change user value!)
+            return number;
+        } else {
+            var t = new Date(number * 1000);
+            var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+            var year = t.getFullYear();
+            var month = months[t.getMonth()];
+            var day = t.getDate();
+            var hour = t.getHours();
+            var min = t.getMinutes();
+            var sec = t.getSeconds();
+            var time = day +'/'+month+'/'+year+' '+hour+':'+min+':'+sec;
+            return time;
+        }
+    }
+}
+]);;

--- a/filters.js
+++ b/filters.js
@@ -133,4 +133,4 @@ angular.module("ch.filters",[])
         }
     }
 }
-]);;
+]);

--- a/test/tests.js
+++ b/test/tests.js
@@ -215,4 +215,12 @@ function executeTests () {
      assert.deepEqual(filter([1, 2, 3, 4]), [4, 3, 2, 1]);
      assert.deepEqual(filter(["Banana", "Orange", "Apple", "Mango"]) , [  "Mango","Apple","Orange", "Banana"]);
    }));
+   
+   it('Tests unixtimestamp filter', inject(function($filter) {
+    var filter = $filter('unixtimestamp');
+    assert.equal(filter('') , '');
+    assert.equal(filter(null) , '');
+    assert.equal(filter(undefined) , '');
+    assert.equal(filter('123456789') , '30  Nov  1973  -  1:3:9');
+}));
 }


### PR DESCRIPTION
I needed to convert Unix timestamp that I received from server to human readable time, and I wrote this simple filter.

It can be useful because:
- Because many databases use Unix timestamp and also it happens that server side returns items' timestamp too.
- Many people need it, according to [this StackOverflow question](http://stackoverflow.com/questions/847185/convert-a-unix-timestamp-to-time-in-javascript).
- ...
