### PR TITLE
Adding unix timestamp convertor filter

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -113,4 +113,19 @@ angular.module("ch.filters",[])
     return arr.reverse();   
   } 
  }                
+]).filter("timeConvertor", [ function(){
+    return function(number) {
+        // Is the passed data a number?
+        if(isNaN(number) || number < 1) {
+            // If not number, just return the entered value (Do not change user value!)
+            return number;
+        } else {
+            var t = new Date(number * 1000);
+            var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+            var time = t.getDate() +'  '+ months[t.getMonth()]+'  '+t.getFullYear()+'  -  '+t.getHours()+':'+t.getMinutes()+':'+t.getSeconds();
+            console.log(time);
+            return time;
+        }
+    }
+}
 ]);

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,4 +1,3 @@
-   
 function executeTests () {
 
    it('Tests print filter', inject(function($filter) {
@@ -215,4 +214,12 @@ function executeTests () {
      assert.deepEqual(filter([1, 2, 3, 4]), [4, 3, 2, 1]);
      assert.deepEqual(filter(["Banana", "Orange", "Apple", "Mango"]) , [  "Mango","Apple","Orange", "Banana"]);
    }));
+   
+   it('Tests unixtimestamp filter', inject(function($filter) {
+    var filter = $filter('unixtimestamp');
+    assert.equal(filter('') , '');
+    assert.equal(filter(null) , '');
+    assert.equal(filter(undefined) , '');
+    assert.equal(filter('123456789') , '30  Nov  1973  -  1:3:9');
+}));
 }


### PR DESCRIPTION
Unix timestamp uses a lot,  specially when it's used in databases and we need to convert them, this filter will help to convert Unix timestamp to human readable 

**This simple filter I added will convert Unix timestamp, to human readable time.**
