### PR TITLE
New filter to convert unix timestamp to human readable time

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -113,4 +113,19 @@ angular.module("ch.filters",[])
     return arr.reverse();   
   } 
  }                
+]).filter("utixtimeconvertor", [ function(){
+    return function(number) {
+        // Is the passed data a number?
+        if(isNaN(number) || number < 1) {
+            // If not number, just return the entered value (Do not change user value!)
+            return number;
+        } else {
+            var t = new Date(number * 1000);
+            var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+            var time = t.getDate() +'  '+ months[t.getMonth()]+'  '+t.getFullYear()+'  -  '+t.getHours()+':'+t.getMinutes()+':'+t.getSeconds();
+            console.log(time);
+            return time;
+        }
+    }
+}
 ]);


### PR DESCRIPTION
Unix timestamps are popular to use and I had problem to work with Unix timestamps and I made a  simple filter for it, it should be good to have it in filter.js

**It is useful because:**
- Famous databases' timestamp system are Unix timestamp
- Many people have problem with that and this filter can help them ([here](http://stackoverflow.com/questions/847185/convert-a-unix-timestamp-to-time-in-javascript))
- If server returns Unix timestamp, user can convert it to human readable (easy to read) time by adding this simple filter.
- ...
